### PR TITLE
Correct taking cxxstd from ROOT setup

### DIFF
--- a/packages/fccanalyses/package.py
+++ b/packages/fccanalyses/package.py
@@ -33,7 +33,7 @@ class Fccanalyses(CMakePackage, Key4hepPackage):
 
     def cmake_args(self):
       args = [
-              self.define('CMAKE_CXX_STANDARD', self.spec[root].variants['cxxstd'].value),
+              self.define('CMAKE_CXX_STANDARD', self.spec['root'].variants['cxxstd'].value),
               ]
       return args
 


### PR DESCRIPTION
I found small syntax error in the fcc-analyses recipe, fixed here